### PR TITLE
Fix random include failure

### DIFF
--- a/src/loadShader.ts
+++ b/src/loadShader.ts
@@ -41,8 +41,6 @@ export async function load(filePath: string, cache: Map<string, string>,
 	const warnings: PartialMessage[] = [];
 	const watchFiles = new Set<string>();
 
-	cache.set(filePath, contents);
-
 	const importPattern = /#include +["']([.\\/\w-]+)["']/g;
 	const linebreakRegex = /\r|\n|\r\n/g;
 
@@ -118,6 +116,8 @@ export async function load(filePath: string, cache: Map<string, string>,
 		contents = contents.replace(include.target, include.contents);
 
 	}
+	
+	cache.set(filePath, contents);
 
 	return { contents, warnings, watchFiles: [...watchFiles] };
 


### PR DESCRIPTION
It appears that on certain conditions (files that include which subsequently include other files), depending on the order of files given to the plugin. 

This fixes such that only fully materialised contents are saved in the cache.