### PR TITLE
Implement legal comment preservation option.

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ build({
 |--------|-------------|---------|
 | minify | Enables or disables basic shader minification. | `false` |
 | resolveIncludes | When enabled, shaders can include other shaders with the custom `#include "path"` directive. | `true`  |
+| legalComments | When enabled, preserves comments starting with `//!` or `/*!` and comments containing `@license` or `@preserve`. | `false` |
 
 ### TypeScript
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -25,6 +25,16 @@ export interface GLSLOptions {
 
 	resolveIncludes?: boolean;
 
+	/**
+	 * Enables or disables shader legal comment preservation.
+	 * When enabled, comments starting with `//!` or `/*!`, or comments with the
+	 * text `@license` or `@preserve`, will be preserved.
+	 *
+	 * Default is `false`.
+	 */
+
+	legalComments?: boolean;
+
 }
 
 /**
@@ -34,7 +44,7 @@ export interface GLSLOptions {
  * @return The plugin.
  */
 
-function glsl({ minify = false, resolveIncludes = true }: GLSLOptions = {}): Plugin {
+function glsl({ minify = false, resolveIncludes = true, legalComments = false }: GLSLOptions = {}): Plugin {
 
 	const cache = new Map<string, string>();
 
@@ -47,7 +57,7 @@ function glsl({ minify = false, resolveIncludes = true }: GLSLOptions = {}): Plu
 				const { contents, warnings, watchFiles } = await load(args.path, cache, resolveIncludes);
 
 				return {
-					contents: minify ? minifyShader(contents as string) : contents,
+					contents: minify ? minifyShader(contents as string, legalComments) : contents,
 					warnings,
 					watchFiles,
 					loader: "text"

--- a/test/expected/wgsl-legal.min.js
+++ b/test/expected/wgsl-legal.min.js
@@ -1,0 +1,7 @@
+var o=`struct PointLight{position:vec3f,color:vec3f}struct LightStorage{pointCount:u32,point:array<PointLight>}@group(0)@binding(0)var<storage> lights:LightStorage;@group(1)@binding(0)var baseColorSampler:sampler;@group(1)@binding(1)var baseColorTexture:texture_2d<f32>;@fragment fn fragmentMain(@location(0)worldPos:vec3f,@location(1)normal:vec3f,@location(2)uv:vec2f)->@location(0)vec4f{let baseColor=textureSample(baseColorTexture,baseColorSampler,uv);let N=normalize(normal);var surfaceColor=vec3f(0);for(var i=0u;i<lights.pointCount;i++){let worldToLight=lights.point[i].position-worldPos;let dist=length(worldToLight);let dir=normalize(worldToLight);let radiance=lights.point[i].color*(1/pow(dist,2));let nDotL=max(dot(N,dir),0);surfaceColor+=baseColor.rgb*radiance*nDotL;}return vec4(surfaceColor,baseColor.a);}
+//! This is a single-line legal comment
+/*!
+* This is a multi-line legal comment.
+*/
+// @license This is a comment that specifies a license.
+// @preserve This is a comment that should be preserved.`;console.log(o);

--- a/test/src/shader.wgsl
+++ b/test/src/shader.wgsl
@@ -51,3 +51,10 @@ fn fragmentMain(
 	return vec4(surfaceColor, baseColor.a);
 
 }
+
+//! This is a single-line legal comment
+/*!
+* This is a multi-line legal comment.
+*/
+// @license This is a comment that specifies a license.
+// @preserve This is a comment that should be preserved.

--- a/test/test.js
+++ b/test/test.js
@@ -96,3 +96,27 @@ test("can use include", async(t) => {
 	});
 
 });
+
+test("can preserve legal comments", async(t) => {
+
+	const config = {
+		entryPoints: ["test/src/wgsl.ts"],
+		outfile: "test/generated/wgsl-legal.min.js",
+		platform: "node",
+		format: "esm",
+		bundle: true,
+		minify: true,
+		legalComments: "inline",
+		plugins: [glsl({ minify: true, legalComments: true })]
+	};
+
+	return build(config).then(async() => {
+
+		const actual = await readFile("test/generated/wgsl-legal.min.js", "utf8");
+		const expected = await readFile("test/expected/wgsl-legal.min.js", "utf8");
+
+		t.is(actual.replace(EOL, ""), expected.replace(EOL, ""));
+
+	});
+
+});


### PR DESCRIPTION
Delivers on #11.

I'm not too familiar with the test structure, so while it is failing, it looks to me to be very close to passing.

This adds a new `legalComments` boolean config option. It defaults to `false` to accommodate existing usage and the fact that **all** comments are currently stripped.

Works for `//!`, `/*!`, `@license`, and `@preserve` as described by the relevant esbuild option. Unlike esbuild, this does not support advanced replacement options; legal comments are either preserved or discarded.