### PR TITLE
Fix legal comment line breaks.

### DIFF
--- a/src/minifyShader.ts
+++ b/src/minifyShader.ts
@@ -37,6 +37,8 @@ function stripComments(source: string, legalComments: LegalComment[] | null = nu
 
 		if(legalCommentRegExp.test(comment[0])) {
 
+			comment[0].replace(/\n*$/g, "");
+
 			const placeholder = `[[LEGAL_COMMENT_${id++}]]`;
 
 			legalComments.push({
@@ -125,7 +127,7 @@ export function minifyShader(source: string, preserveLegalComments: boolean): st
 
 	for(const legalComment of legalComments) {
 
-		result = result.replace(legalComment.placeholder, `\n${legalComment.contents.trim()}`);
+		result = result.replace(legalComment.placeholder, `\n${legalComment.contents.trim()}\n`);
 
 	}
 

--- a/test/expected/wgsl-legal.min.js
+++ b/test/expected/wgsl-legal.min.js
@@ -1,7 +1,9 @@
-var o=`struct PointLight{position:vec3f,color:vec3f}struct LightStorage{pointCount:u32,point:array<PointLight>}@group(0)@binding(0)var<storage> lights:LightStorage;@group(1)@binding(0)var baseColorSampler:sampler;@group(1)@binding(1)var baseColorTexture:texture_2d<f32>;@fragment fn fragmentMain(@location(0)worldPos:vec3f,@location(1)normal:vec3f,@location(2)uv:vec2f)->@location(0)vec4f{let baseColor=textureSample(baseColorTexture,baseColorSampler,uv);let N=normalize(normal);var surfaceColor=vec3f(0);for(var i=0u;i<lights.pointCount;i++){let worldToLight=lights.point[i].position-worldPos;let dist=length(worldToLight);let dir=normalize(worldToLight);let radiance=lights.point[i].color*(1/pow(dist,2));let nDotL=max(dot(N,dir),0);surfaceColor+=baseColor.rgb*radiance*nDotL;}return vec4(surfaceColor,baseColor.a);}
+var o=`struct PointLight{position:vec3f,color:vec3f}struct LightStorage{pointCount:u32,point:array<PointLight>}@group(0)@binding(0)var<storage> lights:LightStorage;@group(1)@binding(0)var baseColorSampler:sampler;@group(1)@binding(1)var baseColorTexture:texture_2d<f32>;@fragment fn fragmentMain(@location(0)worldPos:vec3f,@location(1)normal:vec3f,@location(2)uv:vec2f)->@location(0)vec4f{let baseColor=textureSample(baseColorTexture,baseColorSampler,uv);let N=normalize(normal);var surfaceColor=vec3f(0);for(var i=0u;i<lights.pointCount;i++){let worldToLight=lights.point[i].position-worldPos;let dist=length(worldToLight);let dir=normalize(worldToLight);let radiance=lights.point[i].color*(1/pow(dist,2));let nDotL=max(dot(N,dir),0);surfaceColor+=baseColor.rgb*radiance*nDotL;}
+// @preserve This is a comment that should be preserved.
+return vec4(surfaceColor,baseColor.a);}
 //! This is a single-line legal comment
 /*!
  * This is a multi-line legal comment.
  */
 // @license This is a comment that specifies a license.
-// @preserve This is a comment that should be preserved.`;console.log(o);
+`;console.log(o);

--- a/test/src/shader.wgsl
+++ b/test/src/shader.wgsl
@@ -48,6 +48,7 @@ fn fragmentMain(
 	}
 
 	// Return the accumulated surface color.
+	// @preserve This is a comment that should be preserved.
 	return vec4(surfaceColor, baseColor.a);
 
 }
@@ -57,4 +58,3 @@ fn fragmentMain(
  * This is a multi-line legal comment.
  */
 // @license This is a comment that specifies a license.
-// @preserve This is a comment that should be preserved.


### PR DESCRIPTION
A legal comment followed by code will create a runon statement and fail to execute the affected line of code. This strips all line ending line breaks from legal comments when setting placeholders, and it explicitly sets exactly one line break after the comment to ensure it does not also comment out subsequent statements.

Tagging @vanruesc since IMHO this should be hotfixed ASAP.