### PR TITLE
Use JS loader and export contents.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,10 @@
 name: CI
 
 on:
-  push:
   pull_request:
+  push:
+    branches:
+      - "*"
 
 jobs:
   test:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "esbuild-plugin-glsl",
-	"version": "1.3.1",
+	"version": "1.3.2",
 	"description": "A GLSL plugin for esbuild.",
 	"homepage": "https://github.com/vanruesc/esbuild-plugin-glsl",
 	"license": "Zlib",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -562,8 +562,8 @@ packages:
     resolution: {integrity: sha512-OAcsnTEYu1ARJqWVGwf4zh4JDfHZEaSNlNccFmt8YjB2l/n19/PF2viLINHc57vO4FKIAFl2FWASIGZZWZ2Kxw==}
     engines: {node: '>=10.18.0 <11 || >=12.14.0 <13 || >=14'}
 
-  consola@3.4.0:
-    resolution: {integrity: sha512-EiPU8G6dQG0GFHNR8ljnZFki/8a+cQwEQ+7wpxdChl02Q8HXlwEZWD5lqAF8vC2sEC3Tehr8hy7vErz88LHyUA==}
+  consola@3.4.2:
+    resolution: {integrity: sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA==}
     engines: {node: ^14.18.0 || >=16.10.0}
 
   convert-to-spaces@2.0.1:
@@ -1879,7 +1879,7 @@ snapshots:
 
   '@mapbox/node-pre-gyp@2.0.0':
     dependencies:
-      consola: 3.4.0
+      consola: 3.4.2
       detect-libc: 2.0.3
       https-proxy-agent: 7.0.6
       node-fetch: 2.7.0
@@ -2259,7 +2259,7 @@ snapshots:
       semver: 7.7.1
       well-known-symbols: 2.0.0
 
-  consola@3.4.0: {}
+  consola@3.4.2: {}
 
   convert-to-spaces@2.0.1: {}
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -59,13 +59,15 @@ function glsl({
 
 			async function onLoad(args: OnLoadArgs): Promise<OnLoadResult> {
 
-				const { contents, warnings, watchFiles } = await load(args.path, cache, resolveIncludes);
-
+				let { contents, warnings, watchFiles } = await load(args.path, cache, resolveIncludes);
+				contents = minify
+					? `export default \`${minifyShader(contents as string, preserveLegalComments)}\``
+					: `export default \`${contents as string}\``;
 				return {
-					contents: minify ? minifyShader(contents as string, preserveLegalComments) : contents,
+					contents,
 					warnings,
 					watchFiles,
-					loader: "text"
+					loader: "js"
 				};
 
 			}

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,7 +11,7 @@ export interface GLSLOptions {
 	/**
 	 * Enables or disables shader minification.
 	 *
-	 * @defaultValue inherited from esbuild options, or false if not specified
+	 * Defaults to the value of {@link https://esbuild.github.io/api/#minify} if not specified.
 	 */
 
 	minify?: boolean;
@@ -31,7 +31,7 @@ export interface GLSLOptions {
 	 *
 	 * Legal comments either start with `//!` or `/*!` or include `@license` or `@preserve`.
 	 *
-	 * @defaultValue inherited from esbuild options, or true if not specified
+	 * The default value depends on {@link https://esbuild.github.io/api/#legal-comments} if not specified.
 	 */
 
 	preserveLegalComments?: boolean;

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,7 +11,7 @@ export interface GLSLOptions {
 	/**
 	 * Enables or disables shader minification.
 	 *
-	 * @defaultValue false
+	 * @defaultValue inherited from esbuild options, or false if not specified
 	 */
 
 	minify?: boolean;
@@ -31,7 +31,7 @@ export interface GLSLOptions {
 	 *
 	 * Legal comments either start with `//!` or `/*!` or include `@license` or `@preserve`.
 	 *
-	 * @defaultValue true
+	 * @defaultValue inherited from esbuild options, or true if not specified
 	 */
 
 	preserveLegalComments?: boolean;
@@ -46,9 +46,9 @@ export interface GLSLOptions {
  */
 
 function glsl({
-	minify = false,
+	minify,
 	resolveIncludes = true,
-	preserveLegalComments = true
+	preserveLegalComments
 }: GLSLOptions = {}): Plugin {
 
 	const cache = new Map<string, string>();
@@ -60,9 +60,14 @@ function glsl({
 			async function onLoad(args: OnLoadArgs): Promise<OnLoadResult> {
 
 				let { contents, warnings, watchFiles } = await load(args.path, cache, resolveIncludes);
+
+				minify ??= build.initialOptions.minify ?? false;
+				preserveLegalComments ??= build.initialOptions.legalComments !== "none";
+
 				contents = minify
 					? `export default \`${minifyShader(contents as string, preserveLegalComments)}\``
 					: `export default \`${contents as string}\``;
+
 				return {
 					contents,
 					warnings,

--- a/src/minifyShader.ts
+++ b/src/minifyShader.ts
@@ -37,8 +37,6 @@ function stripComments(source: string, legalComments: LegalComment[] | null = nu
 
 		if(legalCommentRegExp.test(comment[0])) {
 
-			comment[0].replace(/\n*$/g, "");
-
 			const placeholder = `[[LEGAL_COMMENT_${id++}]]`;
 
 			legalComments.push({

--- a/test/expected/glsl.js
+++ b/test/expected/glsl.js
@@ -1,5 +1,68 @@
 // test/src/shader.glsl
-var shader_default = "#include <something>\n\n#ifdef GL_FRAGMENT_PRECISION_HIGH\n\n	uniform highp sampler2D buffer;\n\n#else\n\n	uniform mediump sampler2D buffer;\n\n#endif\n\nuniform mat4 m4;\nvarying vec2 vUv;\n\n/**\n * Multiline\n * comment\n */\n\nfloat testInnerMacros(const in float x) {\n\n	#ifdef MUTE_X\n\n		return 0.0;\n\n	#else\n\n		return x;\n\n	#endif\n\n}\n\nvoid main() {\n\n	int taps = 0;\n\n	for(int i = 0; i < SAMPLES_INT; ++i) {\n\n		++taps; // Inline comment\n\n	}\n\n	// Test weird else if\n	if(taps === 0) {\n\n		gl_FragColor.r = 1.0;\n\n	} else\n	if (taps === 10) {\n\n		gl_FragColor.g = 1.0;\n\n	}\n	else\n	{\n		gl_FragColor.b = 1.0;\n	}\n\n	gl_FragColor.a = (taps == 42) ? 1.0 : 0.0;\n\n}\n";
+var shader_default = `#include <something>
+
+#ifdef GL_FRAGMENT_PRECISION_HIGH
+
+	uniform highp sampler2D buffer;
+
+#else
+
+	uniform mediump sampler2D buffer;
+
+#endif
+
+uniform mat4 m4;
+varying vec2 vUv;
+
+/**
+ * Multiline
+ * comment
+ */
+
+float testInnerMacros(const in float x) {
+
+	#ifdef MUTE_X
+
+		return 0.0;
+
+	#else
+
+		return x;
+
+	#endif
+
+}
+
+void main() {
+
+	int taps = 0;
+
+	for(int i = 0; i < SAMPLES_INT; ++i) {
+
+		++taps; // Inline comment
+
+	}
+
+	// Test weird else if
+	if(taps === 0) {
+
+		gl_FragColor.r = 1.0;
+
+	} else
+	if (taps === 10) {
+
+		gl_FragColor.g = 1.0;
+
+	}
+	else
+	{
+		gl_FragColor.b = 1.0;
+	}
+
+	gl_FragColor.a = (taps == 42) ? 1.0 : 0.0;
+
+}
+`;
 
 // test/src/glsl.ts
 console.log(shader_default);

--- a/test/expected/glsl.min.js
+++ b/test/expected/glsl.min.js
@@ -1,4 +1,4 @@
-var r=`#include <something>
+var e=`#include <something>
 #ifdef GL_FRAGMENT_PRECISION_HIGH
 uniform highp sampler2D buffer;
 #else
@@ -10,4 +10,4 @@ return 0.0;
 #else
 return x;
 #endif
-}void main(){int taps=0;for(int i=0;i<SAMPLES_INT;++i){++taps;}if(taps===0){gl_FragColor.r=1.0;}else if(taps===10){gl_FragColor.g=1.0;}else{gl_FragColor.b=1.0;}gl_FragColor.a=(taps==42)?1.0:0.0;}`;console.log(r);
+}void main(){int taps=0;for(int i=0;i<SAMPLES_INT;++i){++taps;}if(taps===0){gl_FragColor.r=1.0;}else if(taps===10){gl_FragColor.g=1.0;}else{gl_FragColor.b=1.0;}gl_FragColor.a=(taps==42)?1.0:0.0;}`;console.log(e);

--- a/test/expected/include.js
+++ b/test/expected/include.js
@@ -1,5 +1,72 @@
 // test/src/include.glsl
-var include_default = "uniform float f;\n\n#include <something>\n\n#ifdef GL_FRAGMENT_PRECISION_HIGH\n\n	uniform highp sampler2D buffer;\n\n#else\n\n	uniform mediump sampler2D buffer;\n\n#endif\n\nuniform mat4 m4;\nvarying vec2 vUv;\n\n/**\n * Multiline\n * comment\n */\n\nfloat testInnerMacros(const in float x) {\n\n	#ifdef MUTE_X\n\n		return 0.0;\n\n	#else\n\n		return x;\n\n	#endif\n\n}\n\nvoid main() {\n\n	int taps = 0;\n\n	for(int i = 0; i < SAMPLES_INT; ++i) {\n\n		++taps; // Inline comment\n\n	}\n\n	// Test weird else if\n	if(taps === 0) {\n\n		gl_FragColor.r = 1.0;\n\n	} else\n	if (taps === 10) {\n\n		gl_FragColor.g = 1.0;\n\n	}\n	else\n	{\n		gl_FragColor.b = 1.0;\n	}\n\n	gl_FragColor.a = (taps == 42) ? 1.0 : 0.0;\n\n}\n\n";
+var include_default = `uniform float f;
+
+#include <something>
+
+#ifdef GL_FRAGMENT_PRECISION_HIGH
+
+	uniform highp sampler2D buffer;
+
+#else
+
+	uniform mediump sampler2D buffer;
+
+#endif
+
+uniform mat4 m4;
+varying vec2 vUv;
+
+/**
+ * Multiline
+ * comment
+ */
+
+float testInnerMacros(const in float x) {
+
+	#ifdef MUTE_X
+
+		return 0.0;
+
+	#else
+
+		return x;
+
+	#endif
+
+}
+
+void main() {
+
+	int taps = 0;
+
+	for(int i = 0; i < SAMPLES_INT; ++i) {
+
+		++taps; // Inline comment
+
+	}
+
+	// Test weird else if
+	if(taps === 0) {
+
+		gl_FragColor.r = 1.0;
+
+	} else
+	if (taps === 10) {
+
+		gl_FragColor.g = 1.0;
+
+	}
+	else
+	{
+		gl_FragColor.b = 1.0;
+	}
+
+	gl_FragColor.a = (taps == 42) ? 1.0 : 0.0;
+
+}
+
+
+`;
 
 // test/src/include.ts
 console.log(include_default);


### PR DESCRIPTION
Line breaks should be retained when either (a) not minifying, or (b) preserving legal comments. This switches the esbuild loader to `"js"` and creates the returned contents as a template literal instead of string. It also updates tests to conform to the template literal implementation.